### PR TITLE
Add default SerializerContext to serializer, update builder

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -78,26 +78,16 @@ you can set a ``SerializationContextFactory`` to the Serializer.
 
 Example using the SerializerBuilder::
 
-    $serializer = JMS\Serializer\SerializerBuilder::create()
-        ->setDefaultSerializationContextFactory(new MySerializationContextFactory())
-        ->build()
-    ;
-
-And ``MySerializationContextFactory`` must implements interface
-``JMS\Serializer\ContextFactory\SerializationContextFactoryInterface``::
-
-    use JMS\Serializer\ContextFactory\SerializationContextFactoryInterface;
     use JMS\Serializer\SerializationContext;
 
-    class MySerializationContextFactory implements SerializationContextFactoryInterface
-    {
-        public function createSerializationContext()
-        {
+    $serializer = JMS\Serializer\SerializerBuilder::create()
+        ->setDefaultSerializationContextFactory(function () {
             return SerializationContext::create()
                 ->setSerializeNull(true)
             ;
-        }
-    }
+        })
+        ->build()
+    ;
 
 Then, calling ``$serializer->serialize($data, 'json');`` will use your SerializationContext.
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -70,3 +70,40 @@ are located::
 The serializer would expect the metadata files to be named like the fully qualified class names where all ``\`` are
 replaced with ``.``. So, if you class would be named ``Vendor\Package\Foo``, the metadata file would need to be located
 at ``$someDir/Vendor.Package.Foo.(xml|yml)``. For more information, see the :doc:`reference <reference>`.
+
+Setting default SerializationContext factory
+--------------------------------------------
+To avoid to creating a new instance of SerializationContext every time you call method ``serialize()`` (or ``toArray()``),
+you can set a ``SerializationContextFactory`` to the Serializer.
+
+Example using the SerializerBuilder::
+
+    $serializer = JMS\Serializer\SerializerBuilder::create()
+        ->setDefaultSerializationContextFactory(new MySerializationContextFactory())
+        ->build()
+    ;
+
+And ``MySerializationContextFactory`` must implements interface
+``JMS\Serializer\ContextFactory\SerializationContextFactoryInterface``::
+
+    use JMS\Serializer\ContextFactory\SerializationContextFactoryInterface;
+    use JMS\Serializer\SerializationContext;
+
+    class MySerializationContextFactory implements SerializationContextFactoryInterface
+    {
+        public function createSerializationContext()
+        {
+            return SerializationContext::create()
+                ->setSerializeNull(true)
+            ;
+        }
+    }
+
+Then, calling ``$serializer->serialize($data, 'json');`` will use your SerializationContext.
+
+.. note ::
+
+    You can also set a DeserializationContextFactory with
+    ``->setDefaultDeserializationContextFactory(new MyDeserializationContextFactory())``
+    to be used with methods ``deserialize()`` and ``fromArray()``.
+    Your factory then implements ``JMS\Serializer\ContextFactory\DeserializationContextFactoryInterface``.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -71,9 +71,9 @@ The serializer would expect the metadata files to be named like the fully qualif
 replaced with ``.``. So, if you class would be named ``Vendor\Package\Foo``, the metadata file would need to be located
 at ``$someDir/Vendor.Package.Foo.(xml|yml)``. For more information, see the :doc:`reference <reference>`.
 
-Setting default SerializationContext factory
+Setting a default SerializationContext factory
 --------------------------------------------
-To avoid to creating a new instance of SerializationContext
+To avoid to pass an instance of SerializationContext
 every time you call method ``serialize()`` (or ``toArray()``),
 you can set a ``SerializationContextFactory`` to the Serializer.
 
@@ -95,7 +95,6 @@ a serialization context from your callable and use it.
 
 .. note ::
 
-    You can also set a DeserializationContextFactory with
-    ``->setDefaultDeserializationContextFactory(new MyDeserializationContextFactory())``
+    You can also set a default DeserializationContextFactory with
+    ``->setDefaultDeserializationContextFactory(function () { /* ... */ })``
     to be used with methods ``deserialize()`` and ``fromArray()``.
-    Your factory then implements ``JMS\Serializer\ContextFactory\DeserializationContextFactoryInterface``.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -73,7 +73,8 @@ at ``$someDir/Vendor.Package.Foo.(xml|yml)``. For more information, see the :doc
 
 Setting default SerializationContext factory
 --------------------------------------------
-To avoid to creating a new instance of SerializationContext every time you call method ``serialize()`` (or ``toArray()``),
+To avoid to creating a new instance of SerializationContext
+every time you call method ``serialize()`` (or ``toArray()``),
 you can set a ``SerializationContextFactory`` to the Serializer.
 
 Example using the SerializerBuilder::
@@ -89,7 +90,8 @@ Example using the SerializerBuilder::
         ->build()
     ;
 
-Then, calling ``$serializer->serialize($data, 'json');`` will use your SerializationContext.
+Then, calling ``$serializer->serialize($data, 'json');`` will generate
+a serialization context from your callable and use it.
 
 .. note ::
 

--- a/src/JMS/Serializer/ContextFactory/CallableContextFactory.php
+++ b/src/JMS/Serializer/ContextFactory/CallableContextFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\ContextFactory;
+
+/**
+ * Context Factory using a callable.
+ */
+abstract class CallableContextFactory
+{
+    /**
+     * @var callable
+     */
+    private $callable;
+
+    /**
+     * @param callable $callable
+     */
+    public function __construct(callable $callable)
+    {
+        $this->callable = $callable;
+    }
+
+    /**
+     * @return mixed
+     */
+    protected function createContext()
+    {
+        $callable = $this->callable;
+
+        return $callable();
+    }
+}

--- a/src/JMS/Serializer/ContextFactory/CallableDeserializationContextFactory.php
+++ b/src/JMS/Serializer/ContextFactory/CallableDeserializationContextFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\ContextFactory;
+
+/**
+ * Deserialization Context Factory using a callable.
+ */
+class CallableDeserializationContextFactory extends CallableContextFactory implements
+    DeserializationContextFactoryInterface
+{
+    /**
+     * {@InheritDoc}
+     */
+    public function createDeserializationContext()
+    {
+        return $this->createContext();
+    }
+}

--- a/src/JMS/Serializer/ContextFactory/CallableSerializationContextFactory.php
+++ b/src/JMS/Serializer/ContextFactory/CallableSerializationContextFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\ContextFactory;
+
+/**
+ * Serialization Context Factory using a callable.
+ */
+class CallableSerializationContextFactory extends CallableContextFactory implements
+    SerializationContextFactoryInterface
+{
+    /**
+     * {@InheritDoc}
+     */
+    public function createSerializationContext()
+    {
+        return $this->createContext();
+    }
+}

--- a/src/JMS/Serializer/ContextFactory/DefaultDeserializationContextFactory.php
+++ b/src/JMS/Serializer/ContextFactory/DefaultDeserializationContextFactory.php
@@ -26,7 +26,7 @@ use JMS\Serializer\DeserializationContext;
 class DefaultDeserializationContextFactory implements DeserializationContextFactoryInterface
 {
     /**
-     * @return DeserializationContext
+     * {@InheritDoc}
      */
     public function createDeserializationContext()
     {

--- a/src/JMS/Serializer/ContextFactory/DefaultDeserializationContextFactory.php
+++ b/src/JMS/Serializer/ContextFactory/DefaultDeserializationContextFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\ContextFactory;
+
+use JMS\Serializer\DeserializationContext;
+
+/**
+ * Default Deserialization Context Factory.
+ */
+class DefaultDeserializationContextFactory implements DeserializationContextFactoryInterface
+{
+    /**
+     * @return DeserializationContext
+     */
+    public function createDeserializationContext()
+    {
+        return new DeserializationContext();
+    }
+}

--- a/src/JMS/Serializer/ContextFactory/DefaultSerializationContextFactory.php
+++ b/src/JMS/Serializer/ContextFactory/DefaultSerializationContextFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\ContextFactory;
+
+use JMS\Serializer\SerializationContext;
+
+/**
+ * Default Serialization Context Factory.
+ */
+class DefaultSerializationContextFactory implements SerializationContextFactoryInterface
+{
+    /**
+     * @return SerializationContext
+     */
+    public function createSerializationContext()
+    {
+        return new SerializationContext();
+    }
+}

--- a/src/JMS/Serializer/ContextFactory/DefaultSerializationContextFactory.php
+++ b/src/JMS/Serializer/ContextFactory/DefaultSerializationContextFactory.php
@@ -26,7 +26,7 @@ use JMS\Serializer\SerializationContext;
 class DefaultSerializationContextFactory implements SerializationContextFactoryInterface
 {
     /**
-     * @return SerializationContext
+     * {@InheritDoc}
      */
     public function createSerializationContext()
     {

--- a/src/JMS/Serializer/ContextFactory/DeserializationContextFactoryInterface.php
+++ b/src/JMS/Serializer/ContextFactory/DeserializationContextFactoryInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\ContextFactory;
+
+use JMS\Serializer\DeserializationContext;
+
+/**
+ * Deserialization Context Factory Interface.
+ */
+interface DeserializationContextFactoryInterface
+{
+    /**
+     * @return DeserializationContext
+     */
+    public function createDeserializationContext();
+}

--- a/src/JMS/Serializer/ContextFactory/SerializationContextFactoryInterface.php
+++ b/src/JMS/Serializer/ContextFactory/SerializationContextFactoryInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\ContextFactory;
+
+use JMS\Serializer\SerializationContext;
+
+/**
+ * Serialization Context Factory Interface.
+ */
+interface SerializationContextFactoryInterface
+{
+    /**
+     * @return SerializationContext
+     */
+    public function createSerializationContext();
+}

--- a/src/JMS/Serializer/SerializerBuilder.php
+++ b/src/JMS/Serializer/SerializerBuilder.php
@@ -18,7 +18,6 @@
 
 namespace JMS\Serializer;
 
-use Closure;
 use JMS\Serializer\Builder\DefaultDriverFactory;
 use JMS\Serializer\Builder\DriverFactoryInterface;
 use JMS\Serializer\Handler\PhpCollectionHandler;
@@ -41,6 +40,8 @@ use JMS\Serializer\Construction\ObjectConstructorInterface;
 use JMS\Serializer\EventDispatcher\Subscriber\DoctrineProxySubscriber;
 use JMS\Serializer\Naming\CamelCaseNamingStrategy;
 use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
+use JMS\Serializer\ContextFactory\SerializationContextFactoryInterface;
+use JMS\Serializer\ContextFactory\DeserializationContextFactoryInterface;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\FileCacheReader;
@@ -337,11 +338,11 @@ class SerializerBuilder
     }
 
     /**
-     * @param Closure $defaultSerializationContextFactory
+     * @param SerializationContextFactoryInterface $defaultSerializationContextFactory
      *
      * @return self
      */
-    public function setDefaultSerializationContextFactory(Closure $defaultSerializationContextFactory)
+    public function setDefaultSerializationContextFactory(SerializationContextFactoryInterface $defaultSerializationContextFactory)
     {
         $this->defaultSerializationContextFactory = $defaultSerializationContextFactory;
 
@@ -349,11 +350,11 @@ class SerializerBuilder
     }
 
     /**
-     * @param Closure $defaultDeserializationContextFactory
+     * @param DeserializationContextFactoryInterface $defaultDeserializationContextFactory
      *
      * @return self
      */
-    public function setDefaultDeserializationContextFactory(Closure $defaultDeserializationContextFactory)
+    public function setDefaultDeserializationContextFactory(DeserializationContextFactoryInterface $defaultDeserializationContextFactory)
     {
         $this->defaultDeserializationContextFactory = $defaultDeserializationContextFactory;
 

--- a/src/JMS/Serializer/SerializerBuilder.php
+++ b/src/JMS/Serializer/SerializerBuilder.php
@@ -18,6 +18,7 @@
 
 namespace JMS\Serializer;
 
+use Closure;
 use JMS\Serializer\Builder\DefaultDriverFactory;
 use JMS\Serializer\Builder\DriverFactoryInterface;
 use JMS\Serializer\Handler\PhpCollectionHandler;
@@ -72,6 +73,8 @@ class SerializerBuilder
     private $annotationReader;
     private $includeInterfaceMetadata = false;
     private $driverFactory;
+    private $defaultSerializationContextFactory;
+    private $defaultDeserializationContextFactory;
 
     public static function create()
     {
@@ -333,6 +336,30 @@ class SerializerBuilder
         return $this;
     }
 
+    /**
+     * @param Closure $defaultSerializationContextFactory
+     *
+     * @return self
+     */
+    public function setDefaultSerializationContextFactory(Closure $defaultSerializationContextFactory)
+    {
+        $this->defaultSerializationContextFactory = $defaultSerializationContextFactory;
+
+        return $this;
+    }
+
+    /**
+     * @param Closure $defaultDeserializationContextFactory
+     *
+     * @return self
+     */
+    public function setDefaultDeserializationContextFactory(Closure $defaultDeserializationContextFactory)
+    {
+        $this->defaultDeserializationContextFactory = $defaultDeserializationContextFactory;
+
+        return $this;
+    }
+
     public function build()
     {
         $annotationReader = $this->annotationReader;
@@ -368,7 +395,7 @@ class SerializerBuilder
             $this->addDefaultDeserializationVisitors();
         }
 
-        return new Serializer(
+        $serializer = new Serializer(
             $metadataFactory,
             $this->handlerRegistry,
             $this->objectConstructor ?: new UnserializeObjectConstructor(),
@@ -376,6 +403,16 @@ class SerializerBuilder
             $this->deserializationVisitors,
             $this->eventDispatcher
         );
+
+        if (null !== $this->defaultSerializationContextFactory) {
+            $serializer->setDefaultSerializationContextFactory($this->defaultSerializationContextFactory);
+        }
+
+        if (null !== $this->defaultDeserializationContextFactory) {
+            $serializer->setDefaultDeserializationContextFactory($this->defaultDeserializationContextFactory);
+        }
+
+        return $serializer;
     }
 
     private function initializePropertyNamingStrategy()

--- a/src/JMS/Serializer/SerializerBuilder.php
+++ b/src/JMS/Serializer/SerializerBuilder.php
@@ -42,6 +42,8 @@ use JMS\Serializer\Naming\CamelCaseNamingStrategy;
 use JMS\Serializer\Naming\PropertyNamingStrategyInterface;
 use JMS\Serializer\ContextFactory\SerializationContextFactoryInterface;
 use JMS\Serializer\ContextFactory\DeserializationContextFactoryInterface;
+use JMS\Serializer\ContextFactory\CallableSerializationContextFactory;
+use JMS\Serializer\ContextFactory\CallableDeserializationContextFactory;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\FileCacheReader;
@@ -338,25 +340,41 @@ class SerializerBuilder
     }
 
     /**
-     * @param SerializationContextFactoryInterface $defaultSerializationContextFactory
+     * @param SerializationContextFactoryInterface|callable $defaultSerializationContextFactory
      *
      * @return self
      */
-    public function setDefaultSerializationContextFactory(SerializationContextFactoryInterface $defaultSerializationContextFactory)
+    public function setDefaultSerializationContextFactory($defaultSerializationContextFactory)
     {
-        $this->defaultSerializationContextFactory = $defaultSerializationContextFactory;
+        if ($defaultSerializationContextFactory instanceof SerializationContextFactoryInterface) {
+            $this->defaultSerializationContextFactory = $defaultSerializationContextFactory;
+        } elseif (is_callable($defaultSerializationContextFactory)) {
+            $this->defaultSerializationContextFactory = new CallableSerializationContextFactory(
+                $defaultSerializationContextFactory
+            );
+        } else {
+            throw new InvalidArgumentException('expected SerializationContextFactoryInterface or callable.');
+        }
 
         return $this;
     }
 
     /**
-     * @param DeserializationContextFactoryInterface $defaultDeserializationContextFactory
+     * @param DeserializationContextFactoryInterface|callable $defaultDeserializationContextFactory
      *
      * @return self
      */
-    public function setDefaultDeserializationContextFactory(DeserializationContextFactoryInterface $defaultDeserializationContextFactory)
+    public function setDefaultDeserializationContextFactory($defaultDeserializationContextFactory)
     {
-        $this->defaultDeserializationContextFactory = $defaultDeserializationContextFactory;
+        if ($defaultDeserializationContextFactory instanceof DeserializationContextFactoryInterface) {
+            $this->defaultDeserializationContextFactory = $defaultDeserializationContextFactory;
+        } elseif (is_callable($defaultDeserializationContextFactory)) {
+            $this->defaultDeserializationContextFactory = new CallableDeserializationContextFactory(
+                $defaultDeserializationContextFactory
+            );
+        } else {
+            throw new InvalidArgumentException('expected DeserializationContextFactoryInterface or callable.');
+        }
 
         return $this;
     }

--- a/tests/JMS/Serializer/Tests/Serializer/SerializationContextFactoryTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/SerializationContextFactoryTest.php
@@ -74,7 +74,7 @@ class SerializationContextFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{"value":null}', $result);
     }
 
-    public function testDeserializeUseProvidedSerializationContext()
+    public function testDeserializeUseProvidedDeserializationContext()
     {
         $contextFactoryMock = $this->getMockForAbstractClass('JMS\\Serializer\\ContextFactory\\DeserializationContextFactoryInterface');
         $context = new DeserializationContext();
@@ -88,6 +88,43 @@ class SerializationContextFactoryTest extends \PHPUnit_Framework_TestCase
         $this->serializer->setDefaultDeserializationContextFactory($contextFactoryMock);
 
         $result = $this->serializer->deserialize('{"value":null}', 'array', 'json');
+
+        $this->assertEquals(array('value' => null), $result);
+    }
+
+    public function testToArrayUseProvidedSerializationContext()
+    {
+        $contextFactoryMock = $this->getMockForAbstractClass('JMS\\Serializer\\ContextFactory\\SerializationContextFactoryInterface');
+        $context = new SerializationContext();
+        $context->setSerializeNull(true);
+
+        $contextFactoryMock
+            ->expects($this->once())
+            ->method('createSerializationContext')
+            ->will($this->returnValue($context))
+        ;
+
+        $this->serializer->setDefaultSerializationContextFactory($contextFactoryMock);
+
+        $result = $this->serializer->toArray(array('value' => null));
+
+        $this->assertEquals(array('value' => null), $result);
+    }
+
+    public function testFromArrayUseProvidedDeserializationContext()
+    {
+        $contextFactoryMock = $this->getMockForAbstractClass('JMS\\Serializer\\ContextFactory\\DeserializationContextFactoryInterface');
+        $context = new DeserializationContext();
+
+        $contextFactoryMock
+            ->expects($this->once())
+            ->method('createDeserializationContext')
+            ->will($this->returnValue($context))
+        ;
+
+        $this->serializer->setDefaultDeserializationContextFactory($contextFactoryMock);
+
+        $result = $this->serializer->fromArray(array('value' => null), 'array');
 
         $this->assertEquals(array('value' => null), $result);
     }

--- a/tests/JMS/Serializer/Tests/Serializer/SerializationContextFactoryTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/SerializationContextFactoryTest.php
@@ -19,10 +19,6 @@
 namespace JMS\Serializer\Tests\Serializer;
 
 use JMS\Serializer\Handler\HandlerRegistry;
-use JMS\Serializer\Tests\Fixtures\Author;
-use JMS\Serializer\Tests\Fixtures\AuthorList;
-use JMS\Serializer\Tests\Fixtures\Order;
-use JMS\Serializer\Tests\Fixtures\Price;
 use PhpCollection\Map;
 use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
 use Metadata\MetadataFactory;

--- a/tests/JMS/Serializer/Tests/Serializer/SerializationContextFactoryTest.php
+++ b/tests/JMS/Serializer/Tests/Serializer/SerializationContextFactoryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * Copyright 2013 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Serializer;
+
+use JMS\Serializer\Handler\HandlerRegistry;
+use JMS\Serializer\Tests\Fixtures\Author;
+use JMS\Serializer\Tests\Fixtures\AuthorList;
+use JMS\Serializer\Tests\Fixtures\Order;
+use JMS\Serializer\Tests\Fixtures\Price;
+use PhpCollection\Map;
+use JMS\Serializer\Naming\SerializedNameAnnotationStrategy;
+use Metadata\MetadataFactory;
+use JMS\Serializer\Metadata\Driver\AnnotationDriver;
+use Doctrine\Common\Annotations\AnnotationReader;
+use JMS\Serializer\Construction\UnserializeObjectConstructor;
+use JMS\Serializer\JsonSerializationVisitor;
+use JMS\Serializer\JsonDeserializationVisitor;
+use JMS\Serializer\Serializer;
+use JMS\Serializer\Naming\CamelCaseNamingStrategy;
+use JMS\Serializer\SerializationContext;
+use JMS\Serializer\DeserializationContext;
+
+class SerializationContextFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    protected $serializer;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $namingStrategy = new SerializedNameAnnotationStrategy(new CamelCaseNamingStrategy());
+
+        $this->serializer = new Serializer(
+            new MetadataFactory(new AnnotationDriver(new AnnotationReader())),
+            new HandlerRegistry(),
+            new UnserializeObjectConstructor(),
+            new Map(array('json' => new JsonSerializationVisitor($namingStrategy))),
+            new Map(array('json' => new JsonDeserializationVisitor($namingStrategy)))
+        );
+    }
+
+    public function testSerializeUseProvidedSerializationContext()
+    {
+        $contextFactoryMock = $this->getMockForAbstractClass('JMS\\Serializer\\ContextFactory\\SerializationContextFactoryInterface');
+        $context = new SerializationContext();
+        $context->setSerializeNull(true);
+
+        $contextFactoryMock
+            ->expects($this->once())
+            ->method('createSerializationContext')
+            ->will($this->returnValue($context))
+        ;
+
+        $this->serializer->setDefaultSerializationContextFactory($contextFactoryMock);
+
+        $result = $this->serializer->serialize(array('value' => null), 'json');
+
+        $this->assertEquals('{"value":null}', $result);
+    }
+
+    public function testDeserializeUseProvidedSerializationContext()
+    {
+        $contextFactoryMock = $this->getMockForAbstractClass('JMS\\Serializer\\ContextFactory\\DeserializationContextFactoryInterface');
+        $context = new DeserializationContext();
+
+        $contextFactoryMock
+            ->expects($this->once())
+            ->method('createDeserializationContext')
+            ->will($this->returnValue($context))
+        ;
+
+        $this->serializer->setDefaultDeserializationContextFactory($contextFactoryMock);
+
+        $result = $this->serializer->deserialize('{"value":null}', 'array', 'json');
+
+        $this->assertEquals(array('value' => null), $result);
+    }
+}

--- a/tests/JMS/Serializer/Tests/SerializerBuilderTest.php
+++ b/tests/JMS/Serializer/Tests/SerializerBuilderTest.php
@@ -23,6 +23,8 @@ use Symfony\Component\Filesystem\Filesystem;
 use JMS\Serializer\Handler\HandlerRegistry;
 use JMS\Serializer\JsonSerializationVisitor;
 use JMS\Serializer\Naming\CamelCaseNamingStrategy;
+use JMS\Serializer\SerializationContext;
+use JMS\Serializer\DeserializationContext;
 
 class SerializerBuilderTest extends \PHPUnit_Framework_TestCase
 {
@@ -112,6 +114,47 @@ class SerializerBuilderTest extends \PHPUnit_Framework_TestCase
             $this->builder,
             $this->builder->includeInterfaceMetadata(true)
         );
+    }
+
+    public function testSetDefaultSerializationContext()
+    {
+        $contextFactoryMock = $this->getMockForAbstractClass('JMS\\Serializer\\ContextFactory\\SerializationContextFactoryInterface');
+        $context = new SerializationContext();
+        $context->setSerializeNull(true);
+
+        $contextFactoryMock
+            ->expects($this->once())
+            ->method('createSerializationContext')
+            ->will($this->returnValue($context))
+        ;
+
+        $this->builder->setDefaultSerializationContextFactory($contextFactoryMock);
+
+        $serializer = $this->builder->build();
+
+        $result = $serializer->serialize(array('value' => null), 'json');
+
+        $this->assertEquals('{"value":null}', $result);
+    }
+
+    public function testSetDefaultDeserializationContext()
+    {
+        $contextFactoryMock = $this->getMockForAbstractClass('JMS\\Serializer\\ContextFactory\\DeserializationContextFactoryInterface');
+        $context = new DeserializationContext();
+
+        $contextFactoryMock
+            ->expects($this->once())
+            ->method('createDeserializationContext')
+            ->will($this->returnValue($context))
+        ;
+
+        $this->builder->setDefaultDeserializationContextFactory($contextFactoryMock);
+
+        $serializer = $this->builder->build();
+
+        $result = $serializer->deserialize('{"value":null}', 'array', 'json');
+
+        $this->assertEquals(array('value' => null), $result);
     }
 
     protected function setUp()

--- a/tests/JMS/Serializer/Tests/SerializerBuilderTest.php
+++ b/tests/JMS/Serializer/Tests/SerializerBuilderTest.php
@@ -157,6 +157,36 @@ class SerializerBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('value' => null), $result);
     }
 
+    public function testSetCallbackSerializationContextWithSerializeNull()
+    {
+        $this->builder->setDefaultSerializationContextFactory(function () {
+            return SerializationContext::create()
+                ->setSerializeNull(true)
+            ;
+        });
+
+        $serializer = $this->builder->build();
+
+        $result = $serializer->serialize(array('value' => null), 'json');
+
+        $this->assertEquals('{"value":null}', $result);
+    }
+
+    public function testSetCallbackSerializationContextWithNotSerializeNull()
+    {
+        $this->builder->setDefaultSerializationContextFactory(function () {
+            return SerializationContext::create()
+                ->setSerializeNull(false)
+            ;
+        });
+
+        $serializer = $this->builder->build();
+
+        $result = $serializer->serialize(array('value' => null, 'not_null' => 'ok'), 'json');
+
+        $this->assertEquals('{"not_null":"ok"}', $result);
+    }
+
     protected function setUp()
     {
         $this->builder = SerializerBuilder::create();


### PR DESCRIPTION
This PR adds a default `SerializerContext` factory and `SerializerContext` factory in `Serializer` class to avoid to pass a context every time we call `serialize`, `deserialize`, `toArray` or `fromArray`.

It also update the serializer builder by adding `setDefaultSerializerContextFactory` and `setDefaultDeserializerContextFactory` methods, allowing to pass a callable which create a context.

Now we can set a *default serializer context* factory by doing this:

```php
use JMS\Serializer\SerializationContext;

$serializer = \JMS\Serializer\SerializerBuilder::create()
    ->setDefaultSerializationContextFactory(function () {
        return SerializationContext::create()
            ->setSerializeNull(false)
        ;
    })
    ->build()
;
```

Clone of schmittjoh/serializer#541